### PR TITLE
IMG_Load should attempt to read from preloaded data

### DIFF
--- a/IMG.c
+++ b/IMG.c
@@ -126,6 +126,22 @@ void IMG_Quit()
 /* Load an image from a file */
 SDL_Surface *IMG_Load(const char *file)
 {
+#if __EMSCRIPTEN__
+    int w, h;
+    char *data;
+    SDL_Surface *surf;
+
+    data = emscripten_get_preloaded_image_data(file, &w, &h);
+    if (data != NULL) {
+        surf = SDL_CreateRGBSurface(0, w, h, 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000);
+        if (surf != NULL) {
+            memcpy(surf->pixels, data, w * h * 4);
+        }
+        free(data);
+        return surf;
+    }
+#endif
+
     SDL_RWops *src = SDL_RWFromFile(file, "rb");
     const char *ext = strrchr(file, '.');
     if(ext) {


### PR DESCRIPTION
I'm trying to pull data from web then put it on the canvas. After I pass the image data to `emscripten_run_preload_plugins_data`, I use `IMG_Load` to get a surface and I got a NULL pointer.
I read SDL1 test case and it works fine, but SDL2 does not have a test case for `emscripten_run_preload_plugins_data`.

After some digging, I think IMG_Load should attempt to read from preloaded data and here's the fix for IMG_Load.